### PR TITLE
Report SDK Metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .DS_Store
 go.sum
+/log

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/byted-apaas/baas-sdk-go
 go 1.16
 
 require (
-	github.com/byted-apaas/server-common-go v0.0.42
+	github.com/byted-apaas/server-common-go v0.0.44
 	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/gjson v1.14.2
 	go.mongodb.org/mongo-driver v1.12.1

--- a/request/faasinfra/faasinfra.go
+++ b/request/faasinfra/faasinfra.go
@@ -6,8 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"go.mongodb.org/mongo-driver/bson"
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"io/ioutil"
 	"mime/multipart"
 	"net/http"
@@ -15,6 +13,9 @@ import (
 	"reflect"
 	"strconv"
 	"sync"
+
+	"go.mongodb.org/mongo-driver/bson"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 
 	"github.com/byted-apaas/baas-sdk-go/common/constants"
 	"github.com/byted-apaas/baas-sdk-go/common/structs"
@@ -86,6 +87,7 @@ func (r *requestFaaSInfra) InvokeFunctionDistributed(ctx context.Context, appCtx
 		"x-kunlun-loop-masks":   lookMask,
 	}
 
+	ctx = cUtils.SetApiTimeoutMethodToCtx(ctx, cConstants.CreateDistributedTask)
 	data, err := cUtils.ErrorWrapper(getFaaSInfraClient().PostJson(utils.SetAppConfToCtx(ctx, appCtx), GetPathInvokeFunctionDistributed(namespace), headers, body, cHttp.AppTokenMiddleware))
 	if err != nil {
 		return 0, err
@@ -108,6 +110,7 @@ func DoRequestRedis(ctx context.Context, param interface{}) ([]byte, map[string]
 }
 
 func DoRequestFile(ctx context.Context, contentType string, body *bytes.Buffer) ([]byte, error) {
+	ctx = cUtils.SetApiTimeoutMethodToCtx(ctx, cConstants.RequestFile)
 	return cUtils.ErrorWrapper(getFaaSInfraClient().PostFormData(ctx, GetFaaSInfraPathFile(), map[string][]string{
 		cConstants.HttpHeaderKeyContentType: {contentType},
 	}, body, cHttp.AppTokenMiddleware, cHttp.TenantAndUserMiddleware, cHttp.ServiceIDMiddleware))

--- a/request/faasinfra/path.go
+++ b/request/faasinfra/path.go
@@ -1,24 +1,30 @@
 package faasinfra
 
 import (
+	"strings"
+
 	cConstants "github.com/byted-apaas/server-common-go/constants"
 	cUtils "github.com/byted-apaas/server-common-go/utils"
-	"strings"
 )
 
 const (
-	PathInvokeFunction            = "/cloudfunction/v1/namespaces/:namespace/function/invokeSync"
-	PathInvokeFunctionAsync       = "/faasAsyncTask/v1/namespaces/:namespace/asyncTask/CreateAsyncTask"
+	// PathInvokeFunction Deprecated
+	PathInvokeFunction = "/cloudfunction/v1/namespaces/:namespace/function/invokeSync"
+	// PathInvokeFunctionAsync Deprecated
+	PathInvokeFunctionAsync = "/faasAsyncTask/v1/namespaces/:namespace/asyncTask/CreateAsyncTask"
+
 	PathInvokeFunctionDistributed = "/distributedTask/v1/namespaces/:namespace/create"
 	PathFaaSInfraPathMongodb      = "/resource/v3/namespaces/:namespace/db"
 	PathFaaSInfraPathRedis        = "/resource/v2/namespaces/:namespace/cache"
 	FaaSInfraPathFile             = "/resource/v2/namespaces/:namespace/file"
 )
 
+// GetPathInvokeFunction Deprecated
 func GetPathInvokeFunction(namespace string) string {
 	return cUtils.NewPathReplace(PathInvokeFunction).Namespace(namespace).Path()
 }
 
+// GetPathInvokeFunctionAsync Deprecated
 func GetPathInvokeFunctionAsync(namespace string) string {
 	return cUtils.NewPathReplace(PathInvokeFunctionAsync).Namespace(namespace).Path()
 }

--- a/request/openapi/openapi.go
+++ b/request/openapi/openapi.go
@@ -34,7 +34,7 @@ func (r *RequestHttp) InvokeFunctionAsync(ctx context.Context, appCtx *structs.A
 		cConstants.HttpHeaderKeyTenant: {tenantName},
 		cConstants.HttpHeaderKeyUser:   {strconv.FormatInt(cUtils.GetUserIDFromCtx(ctx), 10)},
 	}
-
+	ctx = cUtils.SetApiTimeoutMethodToCtx(ctx, cConstants.CreateAsyncTask)
 	data, err := cUtils.ErrorWrapper(getOpenapiClient().PostJson(utils.SetAppConfToCtx(ctx, appCtx), GetPathInvokeFunctionAsync(namespace), headers, body, cHttp.AppTokenMiddleware))
 	if err != nil {
 		return 0, err

--- a/version/version.go
+++ b/version/version.go
@@ -7,7 +7,7 @@ import (
 	cVersion "github.com/byted-apaas/server-common-go/version"
 )
 
-const Version = "v0.0.15"
+const Version = "v0.0.16"
 
 const SDKName = "byted-apaas/baas-sdk-go"
 


### PR DESCRIPTION
## Summary
- Upgrade server-common-go dependency to v0.0.44-beta.3
- Add API timeout method tracking for SDK metrics

## Test Plan
- [ ] Verify SDK metrics are reported correctly
- [ ] Test API timeout tracking functionality